### PR TITLE
Add error handling for visualizer and file operations

### DIFF
--- a/benches/extreme_points.rs
+++ b/benches/extreme_points.rs
@@ -4,7 +4,7 @@ use geometer::util::polygon_map_by_num_vertices;
 
 
 fn benchmark_extreme_points(c: &mut Criterion) {
-    let polygon_map = polygon_map_by_num_vertices(200usize);
+    let polygon_map = polygon_map_by_num_vertices(200usize).unwrap();
     let mut group = c.benchmark_group("Extreme Points");
     group.sample_size(10);
 

--- a/benches/interior_points.rs
+++ b/benches/interior_points.rs
@@ -4,7 +4,7 @@ use geometer::util::polygon_map_by_num_vertices;
 
 
 fn benchmark_interior_points(c: &mut Criterion) {
-    let polygon_map = polygon_map_by_num_vertices(200usize);
+    let polygon_map = polygon_map_by_num_vertices(200usize).unwrap();
     let mut group = c.benchmark_group("Interior Points");
     group.sample_size(10);
 

--- a/src/bin/generate_rotated_ipa_polygons.rs
+++ b/src/bin/generate_rotated_ipa_polygons.rs
@@ -20,7 +20,7 @@ fn main() {
         let mut dest_json_path = dataset_path.clone();
         dest_json_path.push(src_json_path.file_name().unwrap());
 
-        let mut polygon = Polygon::from_json(&src_json_path);
+        let mut polygon = Polygon::from_json(&src_json_path).unwrap();
         
         // Get a (rounded) bounding box center for translation vector
         let orig_bb = polygon.bounding_box();

--- a/src/bin/generate_rotated_ipa_polygons.rs
+++ b/src/bin/generate_rotated_ipa_polygons.rs
@@ -10,11 +10,6 @@ fn main() {
     let mut orig_path = dataset_path.clone();
     orig_path.push("original");
 
-    // TODO Also writing to visualizer path since they are copied there
-    // until the path resolution for the visualizer is resolved
-    let mut vis_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    vis_path.push("../visualizer/polygons");
-
     for path in fs::read_dir(orig_path).unwrap() {
         let src_json_path = path.unwrap().path();
         let mut dest_json_path = dataset_path.clone();
@@ -39,11 +34,6 @@ fn main() {
         let y = orig_bb_center.y - new_bb_center.y;
         polygon.translate(x, y);
 
-        polygon.to_json(dest_json_path);
-
-        // TODO will remove this when paths are resolved for visualizer
-        let mut vis_json_path = vis_path.clone();
-        vis_json_path.push(src_json_path.file_name().unwrap());
-        polygon.to_json(vis_json_path);
+        let _ = polygon.to_json(dest_json_path);
     }
 }

--- a/src/bin/run_visualizer.rs
+++ b/src/bin/run_visualizer.rs
@@ -142,7 +142,7 @@ impl RerunVisualizer {
 }
 
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), VisualizationError> {
     let args = Args::parse();
     let visualizer = RerunVisualizer::new("Geometer".to_string());
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+
+#[derive(Debug)]
+pub enum FileError {
+    IOError(io::Error),
+    ParseError(serde_json::Error),
+}
+
+impl From<io::Error> for FileError {
+    fn from(value: io::Error) -> Self {
+        FileError::IOError(value)
+    }
+}
+
+impl From<serde_json::Error> for FileError {
+    fn from(value: serde_json::Error) -> Self {
+        FileError::ParseError(value)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,18 +3,18 @@ use std::io;
 
 #[derive(Debug)]
 pub enum FileError {
-    IOError(io::Error),
-    ParseError(serde_json::Error),
+    IO(io::Error),
+    Parse(serde_json::Error),
 }
 
 impl From<io::Error> for FileError {
     fn from(value: io::Error) -> Self {
-        FileError::IOError(value)
+        FileError::IO(value)
     }
 }
 
 impl From<serde_json::Error> for FileError {
     fn from(value: serde_json::Error) -> Self {
-        FileError::ParseError(value)
+        FileError::Parse(value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 const F64_ASSERT_PRECISION: f64 = 1e-4f64;
 
 pub mod bounding_box;
+pub mod error;
 pub mod line_segment;
 pub mod point;
 pub mod polygon;

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -542,7 +542,7 @@ mod tests {
         let filename = NamedTempFile::new()
             .unwrap()
             .into_temp_path();
-        case.polygon.to_json(&filename);
+        let _ = case.polygon.to_json(&filename);
         let new_polygon = Polygon::from_json(&filename).unwrap();
         assert_eq!(case.polygon, new_polygon);
     }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -53,14 +53,11 @@ impl Polygon {
         Ok(Polygon::new(points))
     }
 
-    pub fn to_json<P: AsRef<Path>>(&self, path: P) {
-        // TODO return result
-
+    pub fn to_json<P: AsRef<Path>>(&self, path: P) -> Result<(), FileError>{
         let points = self.vertex_map.sorted_points();
-        let points_str = serde_json::to_string_pretty(&points).unwrap();
-        // TODO don't expect below or unwrap above, want to return result
-        // where it can possibly error on serialization or file write
-        fs::write(path, points_str).expect("File should have saved but failed");
+        let points_str = serde_json::to_string_pretty(&points)?;
+        fs::write(path, points_str)?;
+        Ok(())
     }
  
     pub fn sorted_points(&self) -> Vec<Point> {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -27,12 +27,11 @@ impl Polygon {
         polygon
     }
 
-    pub fn from_json<P: AsRef<Path>>(path: P) -> Polygon {
+    pub fn from_json<P: AsRef<Path>>(path: P) -> Result<Polygon, serde_json::Error> {
         let polygon_str: String = fs::read_to_string(path)
             .expect("file should exist and be parseable");
-        // TODO don't unwrap
-        let points: Vec<Point> = serde_json::from_str(&polygon_str).unwrap();
-        Polygon::new(points)
+        let points: Vec<Point> = serde_json::from_str(&polygon_str)?;
+        Ok(Polygon::new(points))
     }
 
     pub fn to_json<P: AsRef<Path>>(&self, path: P) {
@@ -417,7 +416,7 @@ mod tests {
             #[fixture]
             fn $name() -> PolygonTestCase {
                 PolygonTestCase::new(
-                    load_polygon(stringify!($name), stringify!($folder)),
+                    load_polygon(stringify!($name), stringify!($folder)).unwrap(),
                     load_metadata(stringify!($name), stringify!($folder))
                 )
             }
@@ -546,7 +545,7 @@ mod tests {
             .unwrap()
             .into_temp_path();
         case.polygon.to_json(&filename);
-        let new_polygon = Polygon::from_json(&filename);
+        let new_polygon = Polygon::from_json(&filename).unwrap();
         assert_eq!(case.polygon, new_polygon);
     }
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -48,8 +48,8 @@ impl Polygon {
     }
 
     pub fn from_json<P: AsRef<Path>>(path: P) -> Result<Polygon, FileError> {
-        let polygon_str: String = fs::read_to_string(path)?;
-        let points: Vec<Point> = serde_json::from_str(&polygon_str)?;
+        let points_str: String = fs::read_to_string(path)?;
+        let points: Vec<Point> = serde_json::from_str(&points_str)?;
         Ok(Polygon::new(points))
     }
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,36 +1,18 @@
 use itertools::Itertools;
-use std::{collections::HashSet, io};
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
 use crate::{
     bounding_box::BoundingBox, 
+    error::FileError,
     line_segment::LineSegment, 
     point::Point, 
     triangle::Triangle, 
     triangulation::{EarNotFoundError, TriangleVertexIds, Triangulation}, 
     vertex::{Vertex, VertexId}, 
-    vertex_map::VertexMap
+    vertex_map::VertexMap,
 };
-
-
-#[derive(Debug)]
-pub enum FileError {
-    IOError(io::Error),
-    ParseError(serde_json::Error),
-}
-
-impl From<io::Error> for FileError {
-    fn from(value: io::Error) -> Self {
-        FileError::IOError(value)
-    }
-}
-
-impl From<serde_json::Error> for FileError {
-    fn from(value: serde_json::Error) -> Self {
-        FileError::ParseError(value)
-    }
-}
 
 
 #[derive(Debug, PartialEq)]

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -398,14 +398,14 @@ mod tests {
         }
     }
 
-    fn load_metadata(name: &str, folder: &str) -> PolygonMetadata {
+    fn load_metadata(name: &str, folder: &str) -> Result<PolygonMetadata, FileError> {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("polygons");
         path.push(folder);
         path.push(format!("{}.meta.json", name));
-        let metadata_str: String = fs::read_to_string(path)
-            .expect("file should exist and be parseable");
-        serde_json::from_str(&metadata_str).unwrap()
+        let metadata_str: String = fs::read_to_string(path)?;
+        let metadata = serde_json::from_str(&metadata_str)?;
+        Ok(metadata)
     }
 
     #[macro_export]
@@ -415,7 +415,7 @@ mod tests {
             fn $name() -> PolygonTestCase {
                 PolygonTestCase::new(
                     load_polygon(stringify!($name), stringify!($folder)).unwrap(),
-                    load_metadata(stringify!($name), stringify!($folder))
+                    load_metadata(stringify!($name), stringify!($folder)).unwrap(),
                 )
             }
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,10 +2,10 @@ use itertools::Itertools;
 use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
 use walkdir::WalkDir;
 
-use crate::polygon::Polygon;
+use crate::polygon::{FileError, Polygon};
 
 
-pub fn load_polygon(name: &str, folder: &str) -> Result<Polygon, serde_json::Error> {
+pub fn load_polygon(name: &str, folder: &str) -> Result<Polygon, FileError> {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("polygons");
     path.push(folder);
@@ -14,7 +14,7 @@ pub fn load_polygon(name: &str, folder: &str) -> Result<Polygon, serde_json::Err
 }
 
 
-pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> Result<HashMap<usize, Polygon>, serde_json::Error> {
+pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> Result<HashMap<usize, Polygon>, FileError> {
     let mut map = HashMap::new();
     let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     root.push("polygons");

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,8 @@ use itertools::Itertools;
 use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
 use walkdir::WalkDir;
 
-use crate::polygon::{FileError, Polygon};
+use crate::error::FileError;
+use crate::polygon::Polygon;
 
 
 pub fn load_polygon(name: &str, folder: &str) -> Result<Polygon, FileError> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use walkdir::WalkDir;
 use crate::polygon::Polygon;
 
 
-pub fn load_polygon(name: &str, folder: &str) -> Polygon {
+pub fn load_polygon(name: &str, folder: &str) -> Result<Polygon, serde_json::Error> {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("polygons");
     path.push(folder);
@@ -14,7 +14,7 @@ pub fn load_polygon(name: &str, folder: &str) -> Polygon {
 }
 
 
-pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> HashMap<usize, Polygon> {
+pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> Result<HashMap<usize, Polygon>, serde_json::Error> {
     let mut map = HashMap::new();
     let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     root.push("polygons");
@@ -27,10 +27,10 @@ pub fn polygon_map_by_num_vertices(vertex_limit: usize) -> HashMap<usize, Polygo
         // Remove .meta.json files
         .filter(|p| p.with_extension("").extension() != Some(OsStr::new("meta")));
     for path in paths.sorted() {
-        let p = Polygon::from_json(path);
+        let p = Polygon::from_json(path)?;
         if p.num_vertices() <= vertex_limit {
             map.insert(p.num_vertices(), p);
         }
     }
-    map
+    Ok(map)
 }


### PR DESCRIPTION
This change adds error handling including custom error types, and removing as many `unwrap` and `expect` as possible. 