### PR TITLE
Add implementation of QuickHull for finding convex hull

### DIFF
--- a/src/line_segment.rs
+++ b/src/line_segment.rs
@@ -93,11 +93,15 @@ impl<'a> LineSegment<'a> {
     }
 
     pub fn distance_to_point(&self, p: &Point) -> f64 {
-        // TODO might be more compact/sensible way to do this
-        // https://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
+        // https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
         let p1_to_p2 = Vector::from(self);
-        let p_to_p1 = Vector::from(&LineSegment::new(p, self.p1));
-        p1_to_p2.cross(&p_to_p1) / p1_to_p2.magnitude()
+        let numerator = (
+            p1_to_p2.y * p.x - 
+            p1_to_p2.x * p.y + 
+            self.p2.x * self.p1.y - 
+            self.p2.y * self.p1.x
+        ).abs(); 
+        numerator / p1_to_p2.magnitude()
     }
 }
 

--- a/src/line_segment.rs
+++ b/src/line_segment.rs
@@ -91,6 +91,14 @@ impl<'a> LineSegment<'a> {
         let cos_theta = p1_to_p2.dot(&p2_to_p) / (p1_to_p2.magnitude() * p2_to_p.magnitude());
         cos_theta.acos()
     }
+
+    pub fn distance_to_point(&self, p: &Point) -> f64 {
+        // TODO might be more compact/sensible way to do this
+        // https://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
+        let p1_to_p2 = Vector::from(self);
+        let p_to_p1 = Vector::from(&LineSegment::new(p, self.p1));
+        p1_to_p2.cross(&p_to_p1) / p1_to_p2.magnitude()
+    }
 }
 
 #[cfg(test)]

--- a/src/point.rs
+++ b/src/point.rs
@@ -39,6 +39,14 @@ impl Point {
         Triangle::new(ab.p1, ab.p2, self).area() >= 0.0
     }
 
+    pub fn right(&self, ab: &LineSegment) -> bool {
+        Triangle::new(ab.p1, ab.p2, self).area() < 0.0
+    }
+
+    pub fn right_on(&self, ab: &LineSegment) -> bool {
+        Triangle::new(ab.p1, ab.p2, self).area() <= 0.0
+    }
+
     pub fn translate(&mut self, x: f64, y: f64) {
         self.x += x;
         self.y += y;

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -332,11 +332,6 @@ impl Polygon {
         &ids - &interior_ids
     }
 
-    pub fn convex_hull(&self) -> ConvexHull {
-        // Alias for the best-performing hull algorithm implemented
-        self.convex_hull_from_gift_wrapping()
-    }
-
     // TODO will need to think about return types, this algorithm will
     // only return I believe a set of extreme points. So maybe it makes
     // sense to define the ConvexHull with that representation, and then

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -365,7 +365,6 @@ impl Polygon {
             let (a, b, s) = stack.pop().unwrap();
             let ab = self.get_line_segment(&a, &b).unwrap();
 
-            // TODO find c with max distance from ab
             let c = s
                 .iter()
                 .max_by_key(|v| OrderedFloat(ab.distance_to_point(&v.coords)))
@@ -379,9 +378,6 @@ impl Polygon {
 
             if !s1.is_empty() { stack.push((a, c, s1)); }
             if !s2.is_empty() { stack.push((c, a, s2)); }
-
-            
-
             if stack.is_empty() { break; }
         }
         convex_hull

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -366,8 +366,6 @@ impl Polygon {
 
         loop {
             let (a, b, s) = stack.pop().unwrap();
-            println!("POINTS: {:?}", s);
-            println!("A: {:?}, B: {:?}", a, b);
             let ab = self.get_line_segment(&a, &b).unwrap();
 
             let c = s
@@ -375,7 +373,6 @@ impl Polygon {
                 .max_by_key(|v| OrderedFloat(ab.distance_to_point(&v.coords)))
                 .unwrap()
                 .id;
-            println!("C: {:?}", c);
             convex_hull.insert(c);
 
             let ac = self.get_line_segment(&a, &c).unwrap();
@@ -393,8 +390,8 @@ impl Polygon {
                 .filter(|v| v.right(&cb))
                 .collect_vec();
 
-            if !s1.is_empty() { println!("PUSHING: a={:?}, c={:?}, s1={:?}", a, c, s1); stack.push((a, c, s1)); }
-            if !s2.is_empty() { println!("PUSHING: c={:?}, b={:?}, s2={:?}", c, b, s2); stack.push((c, b, s2)); }
+            if !s1.is_empty() { stack.push((a, c, s1)); }
+            if !s2.is_empty() { stack.push((c, b, s2)); }
             if stack.is_empty() { break; }
         }
         convex_hull

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -373,15 +373,13 @@ impl Polygon {
             let ac = self.get_line_segment(&a, &c).unwrap();
             let cb = self.get_line_segment(&c, &b).unwrap();
 
-            let s1 = s
-                .iter()
-                .copied() // TODO remove this, couldn't figure out refs
+            let s1 = s.iter()
+                .copied()
                 .filter(|v| v.right(&ac))
                 .collect_vec();
 
-            let s2 = s
-                .iter()
-                .copied() // TODO remove this, couldn't figure out refs
+            let s2 = s.iter()
+                .copied()
                 .filter(|v| v.right(&cb))
                 .collect_vec();
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -349,7 +349,10 @@ impl Polygon {
         let x = self.lowest_rightmost_vertex().id;
         let y = self.highest_leftmost_vertex().id;
         let xy = self.get_line_segment(&x, &y).unwrap();
-        let s = self.vertex_map.values().collect_vec();
+        let s = self.vertex_map
+            .values()
+            .filter(|v| v.id != x && v.id != y)
+            .collect_vec();
 
         convex_hull.insert(x);
         convex_hull.insert(y);
@@ -363,6 +366,8 @@ impl Polygon {
 
         loop {
             let (a, b, s) = stack.pop().unwrap();
+            println!("POINTS: {:?}", s);
+            println!("A: {:?}, B: {:?}", a, b);
             let ab = self.get_line_segment(&a, &b).unwrap();
 
             let c = s
@@ -370,10 +375,12 @@ impl Polygon {
                 .max_by_key(|v| OrderedFloat(ab.distance_to_point(&v.coords)))
                 .unwrap()
                 .id;
+            println!("C: {:?}", c);
             convex_hull.insert(c);
 
             let (s1, s2): (Vec<_>, Vec<_>) = s
                 .into_iter()
+                .filter(|v| v.id != c)
                 .partition(|v| v.right(&ab));
 
             if !s1.is_empty() { stack.push((a, c, s1)); }
@@ -890,6 +897,16 @@ mod tests {
     fn test_convex_hull_from_gift_wrapping(#[case] case: PolygonTestCase) {
         let convex_hull = case.polygon.convex_hull_from_gift_wrapping();
         assert_eq!(convex_hull, case.metadata.convex_hull);
+    }
+
+    // TODO will want to parametrize on more polygons when defined
+    #[rstest]
+    #[case::polygon_1(polygon_1())]
+    fn test_convex_hull_from_quick_hull(#[case] case: PolygonTestCase) {
+        let convex_hull = case.polygon.convex_hull_from_quick_hull();
+        // TODO need to sort out types
+        let expected = HashSet::new();
+        assert_eq!(convex_hull, expected);
     }
 
     #[apply(all_polygons)]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -22,6 +22,15 @@ impl Vector {
     pub fn magnitude(&self) -> f64 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
+
+    pub fn cross(&self, other: &Vector) -> f64 {
+        // TODO 2D cross product is a hack and I'm 
+        // not sure it makes sense, trying to include
+        // for now for distance computation
+        
+
+        todo!()
+    }
 }
 
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -22,15 +22,6 @@ impl Vector {
     pub fn magnitude(&self) -> f64 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
-
-    pub fn cross(&self, other: &Vector) -> f64 {
-        // TODO 2D cross product is a hack and I'm 
-        // not sure it makes sense, trying to include
-        // for now for distance computation
-        
-
-        todo!()
-    }
 }
 
 

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, fmt};
+use std::fmt;
 
 use serde::Deserialize;
 

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 use serde::Deserialize;
 
@@ -59,6 +59,14 @@ impl Vertex {
 
     pub fn left_on(&self, ab: &LineSegment) -> bool {
         self.coords.left_on(ab)
+    }
+
+    pub fn right(&self, ab: &LineSegment) -> bool {
+        self.coords.right(ab)
+    }
+
+    pub fn right_on(&self, ab: &LineSegment) -> bool {
+        self.coords.right_on(ab)
     }
 
     pub fn translate(&mut self, x: f64, y: f64) {


### PR DESCRIPTION
This change adds an implementation of the QuickHull algorithm for finding the convex hull of a 2D polygon. Also adds some minor convenience functions:
- Computation of distance a point is from a line segment
- Searches for particular vertices (e.g. lowest-rightmost, etc.)
- Point/vertex functions for `right` and `right_on` w.r.t. line segments