### PR TITLE
Refactor convex hull to be Polygon

### DIFF
--- a/src/bin/run_visualizer.rs
+++ b/src/bin/run_visualizer.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, ValueEnum};
 use geometer::convex_hull::{ConvexHullComputer, QuickHull};
 use geometer::error::FileError;
-use itertools::Itertools;
 use random_color::RandomColor;
 
 use geometer::polygon::Polygon;
@@ -109,13 +108,7 @@ impl RerunVisualizer {
         let _ = self.visualize_polygon(polygon, &format!("{name}/polygon"), 5.0);
         
         let hull = QuickHull.convex_hull(polygon);
-        let points = hull.get_vertices()
-            .iter()
-            .map(|id| polygon.get_vertex(id).unwrap().coords.clone())
-            .collect_vec();
-        let hull_polygon = Polygon::new(points);
-
-        let _ = self.visualize_polygon(&hull_polygon, &format!("{name}/convex_hull"), 10.0);
+        let _ = self.visualize_polygon(&hull, &format!("{name}/convex_hull"), 10.0);
 
         Ok(())
     }

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -241,28 +241,6 @@ impl ConvexHullComputer for GrahamScan {
 }
 
 
-#[derive(Default)]
-pub struct Incremental;
-
-impl ConvexHullComputer for Incremental { 
-    fn convex_hull(&self, polygon: &Polygon) -> Polygon {
-        let mut ids = polygon.get_vertex_ids().into_iter().collect_vec();
-        ids.sort();
-
-        // Initialize hull with three leftmost vertices
-        let hull = polygon.get_polygon(ids.split_off(3));
-        
-        // TODO iterate over vertices, for each one, find the
-        // upper and lower tangents from the point to the hull.
-
-        // TODO update hull chain prev/next refs to form new
-        // hull.
-
-        todo!()
-    }
-}
-
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -291,6 +291,42 @@ impl ConvexHullComputer for GrahamScan {
 }
 
 
+#[derive(Default)]
+pub struct Incremental;
+
+impl ConvexHullComputer for Incremental {
+    
+    // TODO it's at this stage that it may make sense to consider
+    // making the ConvexHull just, a Polygon. Not sure yet how
+    // difficult that would be yet but it could make a lot of
+    // sense, since now I'll need to be updating refs and
+    // maintaining a sorted vec of vertices, which is all stuff
+    // offered already by Polygon. Plus you'd get a lot for free
+    // with whatever else would be called on Polygon that also
+    // applies to hull. 
+    
+    fn convex_hull(&self, polygon: &Polygon) -> ConvexHull {
+        let mut vertices = polygon.vertices();
+        vertices.sort_by_key(|v| OF(v.coords.x));
+
+        let mut hull = ConvexHull::default();
+
+        // TODO populate hull with first 3 vertices (triangle)
+
+        // TODO iterate over vertices, for each one, find the
+        // upper and lower tangents from the point to the hull.
+        // I think since they're sorted left-to-right, should
+        // able to take uppermost and lowermost vertices of
+        // hull?
+
+        // TODO update hull chain prev/next refs to form new
+        // hull.
+
+        hull
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -246,17 +246,14 @@ pub struct Incremental;
 
 impl ConvexHullComputer for Incremental { 
     fn convex_hull(&self, polygon: &Polygon) -> Polygon {
-        let mut vertices = polygon.vertices();
-        vertices.sort_by_key(|v| OF(v.coords.x));
+        let mut ids = polygon.get_vertex_ids().into_iter().collect_vec();
+        ids.sort();
 
-
-        // TODO populate hull with first 3 vertices (triangle)
-
+        // Initialize hull with three leftmost vertices
+        let hull = polygon.get_polygon(ids.split_off(3));
+        
         // TODO iterate over vertices, for each one, find the
         // upper and lower tangents from the point to the hull.
-        // I think since they're sorted left-to-right, should
-        // able to take uppermost and lowermost vertices of
-        // hull?
 
         // TODO update hull chain prev/next refs to form new
         // hull.

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -27,16 +27,9 @@ pub struct PolygonMetadata {
 }
 
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Polygon {
     vertex_map: HashMap<VertexId, Vertex>,
-}
-
-
-impl Default for Polygon {
-    fn default() -> Self {
-        Self { vertex_map: Default::default() }
-    }
 }
 
 
@@ -220,6 +213,18 @@ impl Polygon {
             }
         }
         None
+    }
+
+    pub fn get_polygon(&self, ids: impl IntoIterator<Item = VertexId>) -> Polygon {
+        let mut vertices = self.get_vertices(ids)
+            .into_iter()
+            .cloned()
+            .collect_vec();
+        // Note this is currently sorting as its primary use is in convex hull,
+        // if it proves useful for this sorting to be optional (i.e. assume the
+        // order of input IDs is as desired) then can make this optional
+        vertices.sort_by_key(|v| v.id);
+        Polygon::from_vertices(vertices)
     }
 
     pub fn distance_between(&self, id_1: &VertexId, id_2: &VertexId) -> f64 {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -179,11 +179,6 @@ impl Polygon {
         self.vertex_map.get_mut(id)
     }
 
-    pub fn get_vertices(&self, ids: impl IntoIterator<Item = VertexId>) -> Vec<&Vertex> {
-        // TODO don't unwrap
-        ids.into_iter().map(|id| self.get_vertex(&id).unwrap()).collect_vec()
-    }
-
     pub fn get_vertex_ids(&self) -> HashSet<VertexId> {
         self.vertex_map.keys().cloned().collect()
     }
@@ -216,14 +211,14 @@ impl Polygon {
     }
 
     pub fn get_polygon(&self, ids: impl IntoIterator<Item = VertexId>) -> Polygon {
-        let mut vertices = self.get_vertices(ids)
-            .into_iter()
-            .cloned()
-            .collect_vec();
         // Note this is currently sorting as its primary use is in convex hull,
         // if it proves useful for this sorting to be optional (i.e. assume the
         // order of input IDs is as desired) then can make this optional
-        vertices.sort_by_key(|v| v.id);
+        let vertices = ids.into_iter()
+            .map(|id| self.get_vertex(&id).unwrap()) // TODO don't unwrap
+            .cloned()
+            .sorted_by_key(|v| v.id)
+            .collect_vec();
         Polygon::from_vertices(vertices)
     }
 


### PR DESCRIPTION
This change refactors the convex hull algorithms to return a `Polygon` instance instead of having a separate convex hull type. This is in preparation to support incremental algorithms that will benefit from the functionality on the `Polygon` struct, but in trying it out it actually simplifies things both in the algorithm code and also in the visualizer. 