### PR TITLE
Add trace data structures

### DIFF
--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -65,7 +65,7 @@ impl ConvexHullComputer for GiftWrapping {
     fn convex_hull(&self, polygon: &Polygon, _tracer: &mut Option<ConvexHullTracer>) -> Polygon {
         info!("Computing convex hull with the GiftWrapping algorithm");
 
-        let mut hull_ids = HullSet::new();
+        let mut hull_ids = HullSet::default();
         let v0 = polygon.rightmost_lowest_vertex();
         hull_ids.insert(v0.id);
 
@@ -96,8 +96,8 @@ impl ConvexHullComputer for QuickHull {
     fn convex_hull(&self, polygon: &Polygon, _tracer: &mut Option<ConvexHullTracer>) -> Polygon {
         info!("Computing convex hull with the QuickHull algorithm");
 
-        let mut hull_ids = HullSet::new();
-        let mut stack = Stack::new();
+        let mut hull_ids = HullSet::default();
+        let mut stack = Stack::default();
 
         let x = polygon.lowest_rightmost_vertex().id;
         let y = polygon.highest_leftmost_vertex().id;
@@ -157,7 +157,7 @@ impl ConvexHullComputer for GrahamScan {
     fn convex_hull(&self, polygon: &Polygon, tracer: &mut Option<ConvexHullTracer>) -> Polygon {
         info!("Computing convex hull with the GrahamScan algorithm");
 
-        let mut stack = Stack::new();
+        let mut stack = Stack::default();
         let mut vertices = polygon.min_angle_sorted_vertices(None, None);
 
         // Add rightmost lowest vertex and the next min-angle vertex

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -4,7 +4,7 @@ use ordered_float::OrderedFloat as OF;
 use std::collections::HashSet;
 use std::fmt;
 
-use crate::{geometry::Geometry, polygon::Polygon, vertex::VertexId};
+use crate::{data_structure::Stack, geometry::Geometry, polygon::Polygon, vertex::VertexId};
 
 #[derive(Default)]
 pub struct ConvexHullTracerStep {
@@ -414,11 +414,10 @@ impl ConvexHullComputer for DivideConquer {
             return polygon.clone();
         }
 
-        let mut split_stack = Vec::new();
-        let mut merge_stack = Vec::new();
+        let mut split_stack = Stack::with_name(String::from("split"));
+        let mut merge_stack = Stack::with_name(String::from("merge"));
 
         let ids = polygon.vertex_ids_by_increasing_x();
-        trace!("Push to split stack: {ids:?}");
         split_stack.push(ids);
 
         while let Some(mut left_ids) = split_stack.pop() {
@@ -427,19 +426,13 @@ impl ConvexHullComputer for DivideConquer {
 
             if left_ids.len() <= 3 && right_ids.len() <= 3 {
                 // Keep leftmost towards bottom of merge stack
-                trace!("Push to merge stack: {left_ids:?}");
-                trace!("Push to merge stack: {right_ids:?}");
                 merge_stack.push(left_ids);
                 merge_stack.push(right_ids);
             } else if left_ids.len() <= 3 {
-                trace!("Push to merge stack: {left_ids:?}");
-                trace!("Push to split stack: {right_ids:?}");
                 merge_stack.push(left_ids);
                 split_stack.push(right_ids);
             } else {
                 // Keep rightmost towards bottom of split stack
-                trace!("Push to split stack: {left_ids:?}");
-                trace!("Push to split stack: {right_ids:?}");
                 split_stack.push(right_ids);
                 split_stack.push(left_ids);
             }
@@ -448,7 +441,6 @@ impl ConvexHullComputer for DivideConquer {
                 right_ids = merge_stack.pop().unwrap();
                 left_ids = merge_stack.pop().unwrap();
                 let merged_ids = self.merge(left_ids, right_ids, polygon);
-                trace!("Push to merge stack: {merged_ids:?}");
                 merge_stack.push(merged_ids);
             }
         }

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -1,5 +1,8 @@
-use log::trace;
+use log::{debug, trace};
+use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
+
+use crate::vertex::VertexId;
 
 pub struct Stack<T> {
     vec: Vec<T>,
@@ -17,6 +20,15 @@ impl<T> Deref for Stack<T> {
 impl<T> DerefMut for Stack<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.vec
+    }
+}
+
+impl<T> IntoIterator for Stack<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
     }
 }
 
@@ -60,5 +72,45 @@ impl<T: std::fmt::Debug> Stack<T> {
             }
         }
         element
+    }
+}
+
+pub struct HullSet {
+    hull: HashSet<VertexId>,
+}
+
+impl Deref for HullSet {
+    type Target = HashSet<VertexId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.hull
+    }
+}
+
+impl DerefMut for HullSet {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.hull
+    }
+}
+
+impl IntoIterator for HullSet {
+    type Item = VertexId;
+    type IntoIter = std::collections::hash_set::IntoIter<VertexId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.hull.into_iter()
+    }
+}
+
+impl HullSet {
+    pub fn new() -> Self {
+        Self {
+            hull: HashSet::new(),
+        }
+    }
+
+    pub fn insert(&mut self, id: VertexId) {
+        debug!("Adding vertex to hull: {id}");
+        self.hull.insert(id);
     }
 }

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -1,0 +1,64 @@
+use log::trace;
+use std::ops::{Deref, DerefMut};
+
+pub struct Stack<T> {
+    vec: Vec<T>,
+    name: Option<String>,
+}
+
+impl<T> Deref for Stack<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+impl<T> DerefMut for Stack<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vec
+    }
+}
+
+impl<T: std::fmt::Debug> Stack<T> {
+    pub fn new() -> Self {
+        Self {
+            vec: Vec::new(),
+            name: None,
+        }
+    }
+
+    pub fn with_name(name: String) -> Self {
+        Self {
+            vec: Vec::new(),
+            name: Some(name),
+        }
+    }
+
+    pub fn push(&mut self, element: T) {
+        if let Some(name) = &self.name {
+            trace!("Push to {name} stack: {element:?}");
+        } else {
+            trace!("Push to stack: {element:?}");
+        }
+        self.vec.push(element);
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        let element = self.vec.pop();
+        if let Some(e) = &element {
+            if let Some(name) = &self.name {
+                trace!("Pop from {name} stack: {e:?}");
+            } else {
+                trace!("Pop from stack: {e:?}");
+            }
+        } else {
+            if let Some(name) = &self.name {
+                trace!("Pop from empty {name} stack");
+            } else {
+                trace!("Pop from empty stack");
+            }
+        }
+        element
+    }
+}

--- a/src/data_structure.rs
+++ b/src/data_structure.rs
@@ -32,14 +32,16 @@ impl<T> IntoIterator for Stack<T> {
     }
 }
 
-impl<T: std::fmt::Debug> Stack<T> {
-    pub fn new() -> Self {
+impl<T> Default for Stack<T> {
+    fn default() -> Self {
         Self {
             vec: Vec::new(),
             name: None,
         }
     }
+}
 
+impl<T: std::fmt::Debug> Stack<T> {
     pub fn with_name(name: String) -> Self {
         Self {
             vec: Vec::new(),
@@ -64,17 +66,16 @@ impl<T: std::fmt::Debug> Stack<T> {
             } else {
                 trace!("Pop from stack: {e:?}");
             }
+        } else if let Some(name) = &self.name {
+            trace!("Pop from empty {name} stack");
         } else {
-            if let Some(name) = &self.name {
-                trace!("Pop from empty {name} stack");
-            } else {
-                trace!("Pop from empty stack");
-            }
+            trace!("Pop from empty stack");
         }
         element
     }
 }
 
+#[derive(Default)]
 pub struct HullSet {
     hull: HashSet<VertexId>,
 }
@@ -103,12 +104,6 @@ impl IntoIterator for HullSet {
 }
 
 impl HullSet {
-    pub fn new() -> Self {
-        Self {
-            hull: HashSet::new(),
-        }
-    }
-
     pub fn insert(&mut self, id: VertexId) {
         debug!("Adding vertex to hull: {id}");
         self.hull.insert(id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ const F64_ASSERT_PRECISION: f64 = 1e-4f64;
 
 pub mod bounding_box;
 pub mod convex_hull;
+pub mod data_structure;
 pub mod error;
 pub mod geometry;
 pub mod line_segment;


### PR DESCRIPTION
This change adds two tracing data structures, a generic `Stack<T>` and `HullSet`. Both are effectively wrappers of their underlying data structures (`Vet` and `HashSet`, respectively) but they add `trace`-level logging when things are added/removed from them. This provides a significant cleanup in the convex hull algorithms so that all the trace logging that was in the algorithms themselves is now hidden away in the calls on the data structure methods. `HullSet` is specific to tracking `VertexId`s that are considered part of the current convex hull. 