### PR TITLE
Add macros for algorithm tracing logs

### DIFF
--- a/src/alg_step.rs
+++ b/src/alg_step.rs
@@ -99,3 +99,29 @@ impl fmt::Display for IncrementalStep {
         Ok(())
     }
 }
+
+#[macro_export]
+macro_rules! log_graham_step {
+    ($idx:expr,$hull_ids:expr) => {
+        debug!(
+            "{}",
+            GrahamScanStep {
+                idx: $idx,
+                hull_ids: $hull_ids,
+                ..Default::default()
+            }
+        );
+    };
+    ($idx:expr,$new_id:expr,$hull_ids:expr) => {
+        debug!(
+            "{}",
+            GrahamScanStep {
+                idx: $idx,
+                new_id: Some($new_id),
+                hull_ids: $hull_ids,
+            }
+        );
+    };
+}
+
+pub(crate) use log_graham_step;

--- a/src/alg_step.rs
+++ b/src/alg_step.rs
@@ -124,4 +124,31 @@ macro_rules! log_graham_step {
     };
 }
 
+#[macro_export]
+macro_rules! log_incremental_step {
+    ($idx:expr,$hull_ids:expr) => {
+        debug!(
+            "{}",
+            IncrementalStep {
+                idx: $idx,
+                hull_ids: $hull_ids,
+                ..Default::default()
+            }
+        );
+    };
+    ($idx:expr,$new_id:expr,$ut_id:expr, $lt_id:expr,$hull_ids:expr) => {
+        debug!(
+            "{}",
+            IncrementalStep {
+                idx: $idx,
+                new_id: Some($new_id),
+                ut_id: Some($ut_id),
+                lt_id: Some($lt_id),
+                hull_ids: $hull_ids,
+            }
+        );
+    };
+}
+
 pub(crate) use log_graham_step;
+pub(crate) use log_incremental_step;

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -3,7 +3,7 @@ use log::{debug, info, trace};
 use ordered_float::OrderedFloat as OF;
 
 use crate::{
-    alg_step::{log_graham_step, GrahamScanStep, IncrementalStep},
+    alg_step::{log_graham_step, log_incremental_step, GrahamScanStep, IncrementalStep},
     data_structure::{HullSet, Stack},
     geometry::Geometry,
     polygon::Polygon,
@@ -484,30 +484,14 @@ impl ConvexHullComputer for Incremental {
         let polygon = polygon.clone_clean_collinear();
         let (mut hull, ids) = self.init_hull_three_leftmost(&polygon);
 
-        debug!(
-            "{}",
-            IncrementalStep {
-                idx: 0,
-                hull_ids: hull.vertex_ids(),
-                ..Default::default()
-            }
-        );
+        log_incremental_step!(0, hull.vertex_ids());
 
         for (idx, new_id) in ids.into_iter().enumerate() {
             let ut_id = self.upper_tangent_vertex(&hull, new_id, &polygon);
             let lt_id = self.lower_tangent_vertex(&hull, new_id, &polygon);
             let hull_ids = self.extract_boundary(hull, new_id, ut_id, lt_id);
 
-            debug!(
-                "{}",
-                IncrementalStep {
-                    idx: idx + 1,
-                    new_id: Some(new_id),
-                    ut_id: Some(ut_id),
-                    lt_id: Some(lt_id),
-                    hull_ids: hull_ids.clone(),
-                }
-            );
+            log_incremental_step!(idx + 1, new_id, ut_id, lt_id, hull_ids.clone());
 
             hull = polygon.get_polygon(hull_ids, false, true);
         }

--- a/src/convex_hull.rs
+++ b/src/convex_hull.rs
@@ -3,7 +3,7 @@ use log::{debug, info, trace};
 use ordered_float::OrderedFloat as OF;
 
 use crate::{
-    alg_step::{GrahamScanStep, IncrementalStep},
+    alg_step::{log_graham_step, GrahamScanStep, IncrementalStep},
     data_structure::{HullSet, Stack},
     geometry::Geometry,
     polygon::Polygon,
@@ -122,14 +122,7 @@ impl ConvexHullComputer for GrahamScan {
         stack.push(polygon.rightmost_lowest_vertex().id);
         stack.push(vertices.remove(0).id);
 
-        debug!(
-            "{}",
-            GrahamScanStep {
-                idx: 0,
-                hull_ids: stack.clone(),
-                ..Default::default()
-            }
-        );
+        log_graham_step!(0, stack.clone());
 
         for (idx, new_v) in vertices.iter().enumerate() {
             debug!("Current vertex: {}", new_v.id);
@@ -150,15 +143,7 @@ impl ConvexHullComputer for GrahamScan {
                     stack.pop();
                 }
 
-                // TODO add macro for this
-                debug!(
-                    "{}",
-                    GrahamScanStep {
-                        idx: idx + 1,
-                        new_id: Some(new_v.id),
-                        hull_ids: stack.clone(),
-                    }
-                );
+                log_graham_step!(idx + 1, new_v.id, stack.clone());
 
                 if stack[stack.len() - 1] == new_v.id {
                     debug!("Current hull is valid, continue to next vertex");


### PR DESCRIPTION
This change adds macros `log_graham_step` and `log_incremental_step` for logging `GrahamScanStep` and `IncrementalStep` instances, respectively. This enables significantly more compact log statements in the core algorithm code.